### PR TITLE
Remove useless addons

### DIFF
--- a/dozorce.rb
+++ b/dozorce.rb
@@ -11,7 +11,7 @@ bot = Cinch::Bot.new do
     c.channels = ['#soulwell']
     c.encoding = 'UTF-8'
     c.plugins.plugins = [
-        Bash,
+        #Bash,
         Calculator,
         Csfd,
         Google,


### PR DESCRIPTION
Our big company is using your bot, so first of all, I would like to tell you, that we really love the work you and your co-workers (especially Frca, boy is he great ...) have done with this project. It helps us very much, makes our IRC channel more comfortable, and allows us to track our csfd profiles! Its really awesome!

But your bot, has one slight problem, we believe. In our opinion, the bash plugin is kind of spammy, lame and useless. So we, as an entire team, haven given our heads together and work for a few weeks on the ideal solution to this problem. Here we would like to present above-mentioned solution, and hope it can make it to master branch, so your bot would be even more awesome (and we could officially be part ofc this project, haha).
